### PR TITLE
Isolada a API key do restante do código

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@
 
 <p>Código: </p>
 
-(em botCredentials.py):
+  (em botCredentials.py):
+
     api_key = 'chave api'
 
-(em TelegramBot.py):
+  (em TelegramBot.py):
+
     bot = telebot.TeleBot(botCredentials.api_key) # Passa a chave do Telegram para a biblioteca
 
     @bot.message_handler('/start')                # Define o comando que o bot ira responder;

--- a/README.md
+++ b/README.md
@@ -17,17 +17,24 @@
 <p>Importando a biblioteca Telebot:</p>
 
     import telebot
+    import botCredentials
+
+<p>Evitando exportar sua chave API por engano pro repositório Git: </p>
+
+    mv _gitignore .gitignore
 
 <p>Código: </p>
 
+(em botCredentials.py):
     api_key = 'chave api'
 
-    bot = telebot.TeleBot(api_key)             # Passa a chave do Telegram para a biblioteca
+(em TelegramBot.py):
+    bot = telebot.TeleBot(botCredentials.api_key) # Passa a chave do Telegram para a biblioteca
 
-    @bot.message_handler('/start')             # Define o comando que o bot ira responder;
-    def comando(mensagem):                     # Criando uma funcao para a resposta;
-        bot.reply_to(mensagem, "Testando")     # Envio da resposta do bot;
+    @bot.message_handler('/start')                # Define o comando que o bot ira responder;
+    def comando(mensagem):                        # Criando uma funcao para a resposta;
+        bot.reply_to(mensagem, "Testando")        # Envio da resposta do bot;
 
 <p>Após fazer tudo isso:</p>
 
-    python bot.py
+    python TelegramBot.py

--- a/TelegramBot.py
+++ b/TelegramBot.py
@@ -1,8 +1,7 @@
 import telebot
+import BotCredentials
 
-api_key = "SUA CHAVE DA API"               # API KEY do bot
-
-bot = telebot.TeleBot(api_key)
+bot = telebot.TeleBot(botCredentials.api_key)
 
 @bot.message_handler('/start')             # Define o comando que o bot ira responder;
 def comando(mensagem):                     # Criando uma funcao para a resposta;

--- a/_gitignore
+++ b/_gitignore
@@ -1,0 +1,1 @@
+BotCredentials.py

--- a/botCredentials.py
+++ b/botCredentials.py
@@ -1,0 +1,1 @@
+api_key = "SUA CHAVE DA API"               # API KEY do bot


### PR DESCRIPTION
Foi criado um mecanismo para isolar a API key do restante do código, além de ter sido criado um arquivo ".gitignore" (inicialmente _gitignore) para evitar que o arquivo com a key seja enviado por engano para o repositório Git. Esse arquivo deve ser mudado de nome logo após a operação de clone no repositório (_gitignore -> .gitignore).